### PR TITLE
Reduce webpack config: Remove unnecessary TypeScript loader

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -22,6 +22,12 @@ const config= {
             use: ['babel-loader', {
                 loader: 'vue-loader',
                 options: {
+                    // This loaders option actually makes no sense because
+                    // we use external scripts rather than embedded ones.
+                    // We leave it to clarify what types we use for external scripts.
+                    loaders: {
+                        ts: 'ts-loader',
+                    },
                     esModule: true,
                 },
             }],

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -22,9 +22,6 @@ const config= {
             use: ['babel-loader', {
                 loader: 'vue-loader',
                 options: {
-                    loaders: {
-                        ts: 'ts-loader',
-                    },
                     esModule: true,
                 },
             }],
@@ -33,9 +30,6 @@ const config= {
             test: /\.ts$/,
             use: ['babel-loader', {
                 loader: 'ts-loader',
-                options: {
-                    appendTsSuffixTo: [/\.vue$/],
-                },
             }],
             exclude: /node_modules/,
         }],


### PR DESCRIPTION
webpack で実質的に使われてないと思われる config を削除しました.
`dist/assets/js/app.js` に差分が出ないことは確認済みです.

- `vue-loader` の `options.loaders.ts`: これは `.vue` の中の `stript` タグの中身を解釈するものな気がしており, `src` で読み込むときは影響しない気がします.
- `ts-loader` の `options. appendTsSuffixTo`: これは `test` を `/\.ts$|\.vue$/` などとしたときに `.vue` のケースに ts-loader を騙す為に名前を変更しているだけのような気がします.
https://github.com/TypeStrong/ts-loader/blob/master/src/index.ts#L30
https://github.com/TypeStrong/ts-loader/tree/master/test/comparison-tests/appendSuffixTo
この例だと `.vue` の中身は TypeScript になっています.

## webpack の解決の仕方 (推測)

```
rooms/
├── index.ts
├── rooms.vue
└── rooms.vue.ts
```

`index.ts` 読まれる (ts-loader)
-> `rooms.vue` を `import`
-> `rooms.vue` 読まれる (vue-loader)
-> `src` で `rooms.vue.ts` 指定
-> `rooms.vue.ts` 読まれる (ts-loader)

となっていて, ここで削除した設定は絡んでいなさそうです.